### PR TITLE
Added ability to specify filename for exporting

### DIFF
--- a/kibana/dotkibana.py
+++ b/kibana/dotkibana.py
@@ -58,7 +58,7 @@ class DotKibana():
         # TODO test return value for success
         return 0
 
-    def do_export(self, mode, path='.', pkg=False):
+    def do_export(self, mode, path='.', pkg=False, filename=None):
         print("Exporting from %s to %s" % (self.index, path))
         if mode == 'all':
             print("Exporting all objects")
@@ -88,10 +88,10 @@ class DotKibana():
             print("%d dashboard objects found" % len(objects))
         if pkg:
             print("Writing package to disk")
-            self.manager.write_pkg_to_file(mode, objects, path)
+            self.manager.write_pkg_to_file(mode, objects, path, filename)
         else:
             print("Writing %d objects to disk" % len(objects))
-            self.manager.write_objects_to_file(objects, path)
+            self.manager.write_objects_to_file(objects, path, filename)
         print("Export complete")
         return 0
 

--- a/kibana/manager.py
+++ b/kibana/manager.py
@@ -181,10 +181,11 @@ class KibanaManager():
                 ts += '-bck'
         return fname
 
-    def write_object_to_file(self, obj, path='.'):
+    def write_object_to_file(self, obj, path='.', filename=None):
         """Convert obj (dict) to json string and write to file"""
         output = self.json_dumps(obj) + '\n'
-        filename = self.safe_filename(obj['_type'], obj['_id'])
+        if filename is None:
+            filename = self.safe_filename(obj['_type'], obj['_id'])
         filename = os.path.join(path, filename)
         self.pr_inf("Writing to file: " + filename)
         with open(filename, 'w') as f:
@@ -196,7 +197,7 @@ class KibanaManager():
         for name, obj in iteritems(objects):
             self.write_object_to_file(obj, path)
 
-    def write_pkg_to_file(self, name, objects, path='.'):
+    def write_pkg_to_file(self, name, objects, path='.', filename=None):
         """Write a list of related objs to file"""
         # Kibana uses an array of docs, do the same
         # as opposed to a dict of docs
@@ -205,7 +206,8 @@ class KibanaManager():
             pkg_objs.append(obj)
         sorted_pkg = sorted(pkg_objs, key=lambda k: k['_id'])
         output = self.json_dumps(sorted_pkg) + '\n'
-        filename = self.safe_filename('Pkg', name)
+        if filename is None:
+            filename = self.safe_filename('Pkg', name)
         filename = os.path.join(path, filename)
         self.pr_inf("Writing to file: " + filename)
         with open(filename, 'w') as f:


### PR DESCRIPTION
Closes #12 

Allows to specify a filename when exporting kibana settings.

But currently just when used within a pyhton script. For the dotkibana-script this is not done. Not sure if somebody want to use it with the script as well.